### PR TITLE
Custom operators

### DIFF
--- a/stdlib/io/main.alta
+++ b/stdlib/io/main.alta
@@ -26,7 +26,7 @@ export class File {
   }
 
   public @copy constructor(other: ref File) {
-    this.open(other.path.data, other.mode.data)
+    this.open(other.path, other.mode)
   }
 
   public function open(path: rawconststring, mode: rawconststring): void {
@@ -35,8 +35,8 @@ export class File {
       this.handle = nullptr
       throw new OpenFailure
     }
-    this.path = new String(path)
-    this.mode = new String(mode)
+    this.path = path
+    this.mode = mode
   }
 
   public function close(): void {
@@ -58,16 +58,16 @@ export class File {
   public function read(count: Size): String {
     let str = new String(count)
     while count > INT_MAX {
-      if !stdio.fgets(str.data, INT_MAX, this.handle) {
+      if !stdio.fgets(str, INT_MAX, this.handle) {
         throw new ReadFailure
       }
       count -= INT_MAX
     }
     # `as int` isn't necessary, but it's used to silence a compiler warning
-    if !stdio.fgets(str.data, count as int, this.handle) {
+    if !stdio.fgets(str, count as int, this.handle) {
       throw new ReadFailure
     }
-    return str.substring(0, length: rawstringLength(str.data))
+    return str.substring(0, length: str.length)
   }
 
   public @read function valid(): bool {
@@ -91,29 +91,32 @@ export class File {
   }
 }
 
-export function print(data: (double | int | char | bool | String)...): void {
-  let result: String
-  for i: Size in 0..data.length {
-    let item = data[i]
-    if item instanceof String {
-      result.append(item as String)
-    } else if item instanceof double {
-      result.append(floatingPointToString<double>(item as double))
-    } else if item instanceof char {
-      result.append(item as char)
-    } else if item instanceof int {
-      result.append(numberToString<int>(item as int))
-    } else if item instanceof bool {
-      result.append((item as bool) ? "true" : "false")
-    } else {
-      # this is literally impossible, but just in case...
-      throw new InvalidArgument
-    }
+export type ConsoleData = double | int | char | bool | String
+
+function toString(data: ConsoleData): String {
+  if data instanceof String {
+    return data as String
+  } else if data instanceof double {
+    return floatingPointToString<double>(data as double)
+  } else if data instanceof char {
+    let char = data as char
+    return new String(&char, 1)
+  } else if data instanceof int {
+    return numberToString<int>(data as int)
+  } else if data instanceof bool {
+    return (data as bool) ? "true" : "false"
   }
-  stdio.printf("%s", result.data)
+  # this is literally impossible, but just in case...
+  throw new InvalidArgument
 }
 
-export function printLine(data: (double | int | char | bool | String)...): void {
+export function print(data: ConsoleData...): void {
+  for i: Size in 0..data.length {
+    stdio.printf("%s", toString(data[i]).data)
+  }
+}
+
+export function printLine(data: ConsoleData...): void {
   for i: Size in 0..data.length {
     print(data[i])
   }
@@ -122,6 +125,13 @@ export function printLine(data: (double | int | char | bool | String)...): void 
 
 export function printLine(message: rawconststring): void {
   stdio.printf("%s\n", message)
+}
+
+export function printError(data: ConsoleData...): void {
+  for i: Size in 0..data.length {
+    stdio.fprintf(stdio.stderr, "%s", toString(data[i]).data)
+  }
+  stdio.fprintf(stdio.stderr, "\n")
 }
 
 export function printError(message: rawconststring): void {

--- a/stdlib/io/main.alta
+++ b/stdlib/io/main.alta
@@ -10,6 +10,7 @@ export stdio.printf as printf
 export class OpenFailure extends Exception {}
 export class CloseFailure extends Exception {}
 export class ReadFailure extends Exception {}
+export class EndOfFile extends Exception {}
 
 export class File {
   private var handle: ptr stdio.FILE = nullptr
@@ -49,7 +50,8 @@ export class File {
 
   public function read(): byte {
     let char = stdio.fgetc(this.handle)
-    if char == stdio.EOF return '\0'
+    if char == stdio.EOF
+      throw new EndOfFile
     return char as byte
   }
 
@@ -82,6 +84,10 @@ export class File {
 
   public to ptr stdio.FILE {
     return this.handle
+  }
+
+  public to bool {
+    return this.valid
   }
 }
 

--- a/stdlib/map/main.alta
+++ b/stdlib/map/main.alta
@@ -15,7 +15,7 @@ export generic class Map<K, V> {
   # @returns a reference to the value
   public function get(key: K): ref V {
     for i: Size in 0..this.keys.length {
-      if this.keys.get(i) == key {
+      if this.keys[i] == key {
         return this.values.get(i)
       }
     }
@@ -28,7 +28,7 @@ export generic class Map<K, V> {
   # @returns `true` if the key is present, `false` otherwise
   public function has(key: K): bool {
     for i: Size in 0..this.keys.length {
-      if this.keys.get(i) == key {
+      if this.keys[i] == key {
         return true
       }
     }

--- a/stdlib/map/main.alta
+++ b/stdlib/map/main.alta
@@ -39,4 +39,8 @@ export generic class Map<K, V> {
   public function getKeys(): Vector<K> {
     return this.keys
   }
+
+  public this[K]: ref V {
+    return this.get($)
+  }
 }

--- a/stdlib/process/main.alta
+++ b/stdlib/process/main.alta
@@ -18,6 +18,10 @@ class Environment {
       throw new InvalidKey
     return new String(tmp)
   }
+
+  public this[String]: String {
+    return this.get($)
+  }
 }
 
 let environment: Environment = new Environment

--- a/stdlib/string/main.alta
+++ b/stdlib/string/main.alta
@@ -304,6 +304,10 @@ export class String {
     return this.prepend($)
   }
 
+  public this ^= byte: ref String {
+    return this.prepend($)
+  }
+
   public this[Size]: ref byte {
     return this.charAt($)
   }

--- a/stdlib/string/main.alta
+++ b/stdlib/string/main.alta
@@ -285,4 +285,10 @@ export class String {
     }
     return false
   }
+
+  public this + String: String {
+    let other = new String(this)
+    other.append($)
+    return other
+  }
 }

--- a/stdlib/string/main.alta
+++ b/stdlib/string/main.alta
@@ -291,4 +291,20 @@ export class String {
     other.append($)
     return other
   }
+
+  public this += String: ref String {
+    return this.append($)
+  }
+
+  public this += byte: ref String {
+    return this.append($)
+  }
+
+  public this ^= String: ref String {
+    return this.prepend($)
+  }
+
+  public this[Size]: ref byte {
+    return this.charAt($)
+  }
 }

--- a/stdlib/util/main.alta
+++ b/stdlib/util/main.alta
@@ -39,25 +39,28 @@ export generic class Pair<T1, T2> {
 }
 
 export function parseFloatingPoint<T>(string: String): T {
-  if string.length < 1 return 0
+  if string.length < 1
+    return 0
   let first: Size = 0
   for i: Size in 0...string.length {
     if i == string.length {
       first = string.length
       break
     }
-    let char = string.charAt(i)
+    let char = string[i]
     if !(char >= '0' && char <= '9') {
       first = i
       break
     }
   }
-  if first == 0 && string.charAt(0) != '.' return 0
+  if first == 0 && string[0] != '.'
+    return 0
   let whole = parseNumber<T>(string.substring(0, to: first))
-  if first == string.length return whole
+  if first == string.length
+    return whole
 
   let isExponent = false
-  let charThere = string.charAt(first)
+  let charThere = string[first]
   if charThere == '.' {
     isExponent = false
   } else if charThere == 'e' || charThere == 'E' {
@@ -73,13 +76,14 @@ export function parseFloatingPoint<T>(string: String): T {
       second = string.length
       break
     }
-    let char = string.charAt(i)
+    let char = string[i]
     if !(char >= '0' && char <= '9') {
       second = i
       break
     }
   }
-  if second == first return whole
+  if second == first
+    return whole
 
   let secondPart = parseNumber<T>(string.substring(first, to: second))
 
@@ -87,8 +91,10 @@ export function parseFloatingPoint<T>(string: String): T {
     return whole * power<T>(10, secondPart)
   } else {
     let decimal = whole + (secondPart / power<T>(10, second - first))
-    if second == string.length return decimal
-    if string.charAt(second) != 'e' && string.charAt(second) != 'E' return decimal
+    if second == string.length
+      return decimal
+    if string[second] != 'e' && string[second] != 'E'
+      return decimal
 
     let third: Size = 0
     ;++second
@@ -97,13 +103,14 @@ export function parseFloatingPoint<T>(string: String): T {
         third = string.length
         break
       }
-      let char = string.charAt(i)
+      let char = string[i]
       if !(char >= '0' && char <= '9') {
         third = i
         break
       }
     }
-    if third == second return decimal
+    if third == second
+      return decimal
 
     let thirdPart = parseNumber<T>(string.substring(second, to: third))
 
@@ -129,7 +136,7 @@ export function numberToString<T>(number: T): String {
     let num = number % mod
     let digit: byte = num * 10 / mod
 
-    result.prepend(digit + '0')
+    result ^= digit + '0'
 
     number -= num
 
@@ -137,10 +144,10 @@ export function numberToString<T>(number: T): String {
   }
 
   if result.length == 0
-    result.append("0")
+    result += '0'
 
   if negate
-    result.prepend("-")
+    result += '-'
 
   return result
 }
@@ -162,14 +169,14 @@ export function floatingPointToString<T>(number: T): String {
     let num = fmod(whole, mod)
     let digit: byte = num * 10 / mod
 
-    result.prepend(digit + '0')
+    result ^= digit + '0'
 
     whole -= num
 
     ;++iteration
   }
 
-  result.append('.')
+  result += '.'
   iteration = 1
 
   while frac > 0 {
@@ -177,7 +184,7 @@ export function floatingPointToString<T>(number: T): String {
     let num = fmod(frac, mod)
     let digit: byte = (frac - num) / mod
 
-    result.append(digit + '0')
+    result += digit + '0'
 
     frac = num
     ;++iteration
@@ -189,10 +196,11 @@ export function floatingPointToString<T>(number: T): String {
     }
   }
 
-  if result.length == 0 || result.charAt(result.length - 1) == '.' result.append("0")
+  if result.length == 0 || result[result.length - 1] == '.'
+    result += '0'
 
   for i: Size in result.length::0 {
-    let char = result.charAt(i - 1)
+    let char = result[i - 1]
     if char != '0' {
       if char == '.' {
         result = result.substring(length: result.length - 1)
@@ -203,7 +211,7 @@ export function floatingPointToString<T>(number: T): String {
   }
 
   if negate
-    result.prepend("-")
+    result ^= '-'
 
   return result
 }

--- a/stdlib/vector/main.alta
+++ b/stdlib/vector/main.alta
@@ -101,4 +101,8 @@ export generic class Vector<T> {
     }
     return other
   }
+
+  public this[Size]: ref T {
+    return this.get($)
+  }
 }


### PR DESCRIPTION
Refer to alta-lang/talta#6 for the corresponding PR in Talta.

In this repository itself, this PR adds operator overloads to various stdlib classes (such as `String`, `Vector`, and `Map`) and updates stdlib code to use them.